### PR TITLE
Tidy up various bits and pieces

### DIFF
--- a/001_vgo_tour/README.md
+++ b/001_vgo_tour/README.md
@@ -1,4 +1,4 @@
-<!-- __JSON: egrunner script.sh
+<!-- __JSON: egrunner script.sh # LONG ONLINE
 
 ### Examples
 
@@ -310,6 +310,12 @@ Please try vgo. Start tagging versions in your repositories. Create and check
 in go.mod files. File issues at golang.org/issue, and please include “x/vgo:”
 at the start of the title. More posts tomorrow. Thanks, and have fun!
 
+### Version details
+
+```
+{{PrintBlockOut "version details" -}}
+```
+
 -->
 
 ### Examples
@@ -485,13 +491,13 @@ created:
 $ vgo test all
 ?   	github.com/you/hello	[no test files]
 ?   	golang.org/x/text/internal/gen	[no test files]
-ok  	golang.org/x/text/internal/tag	0.010s
+ok  	golang.org/x/text/internal/tag	0.004s
 ?   	golang.org/x/text/internal/testtext	[no test files]
-ok  	golang.org/x/text/internal/ucd	0.025s
-ok  	golang.org/x/text/language	0.046s
-ok  	golang.org/x/text/unicode/cldr	0.056s
-ok  	rsc.io/quote	0.006s
-ok  	rsc.io/sampler	0.003s
+ok  	golang.org/x/text/internal/ucd	0.002s
+ok  	golang.org/x/text/language	0.044s
+ok  	golang.org/x/text/unicode/cldr	0.055s
+ok  	rsc.io/quote	0.009s
+ok  	rsc.io/sampler	0.017s
 ```
 
 In the original go command, the package pattern all meant all packages found in
@@ -550,12 +556,12 @@ ok  	golang.org/x/text/unicode/cldr	(cached)
 --- FAIL: TestHello (0.00s)
 	quote_test.go:19: Hello() = "99 bottles of beer on the wall, 99 bottles of beer, ...", want "Hello, world."
 FAIL
-FAIL	rsc.io/quote	0.002s
+FAIL	rsc.io/quote	0.003s
 --- FAIL: TestHello (0.00s)
 	hello_test.go:31: Hello([en-US fr]) = "99 bottles of beer on the wall, 99 bottles of beer, ...", want "Hello, world."
 	hello_test.go:31: Hello([fr en-US]) = "99 bottles of beer on the wall, 99 bottles of beer, ...", want "Bonjour le monde."
 FAIL
-FAIL	rsc.io/sampler	0.003s
+FAIL	rsc.io/sampler	0.002s
 ```
 
 It appears that something is wrong with rsc.io/sampler v1.99.99. Sure enough:
@@ -688,7 +694,7 @@ require (
 $ vgo test all
 vgo: downloading rsc.io/quote v1.3.0
 ?   	github.com/you/hello	[no test files]
-ok  	rsc.io/quote	0.002s
+ok  	rsc.io/quote	0.003s
 ```
 
 Let's go back to the state where everything is the latest version, including
@@ -786,8 +792,7 @@ check out the quote module, using an ordinary git command:
 
 
 ```
-$ git clone https://github.com/rsc/quote ../quote
-Cloning into '../quote'...
+$ git clone -q https://github.com/rsc/quote ../quote
 ```
 
 Then edit ../quote/quote.go to change something about func Hello. For example,
@@ -831,12 +836,10 @@ fork github.com/rsc/quote and then push your change to your fork.
 ```
 $ cd ../quote
 $ git commit -a -m 'my fork'
-[master 2908baf] my fork
+[master 323d605] my fork
  1 file changed, 1 insertion(+), 1 deletion(-)
 $ git tag v0.0.0-myfork
-$ git push https://github.com/$GITHUB_USERNAME/vgo-by-example-quote-fork v0.0.0-myfork
-To https://github.com/myitcv/vgo-by-example-quote-fork
- * [new tag]         v0.0.0-myfork -> v0.0.0-myfork
+$ git push -q https://github.com/$GITHUB_USERNAME/vgo-by-example-quote-fork v0.0.0-myfork
 ```
 
 Then you can use that as the replacement:
@@ -894,5 +897,12 @@ directories entirely, as will module-aware go command builds.
 Please try vgo. Start tagging versions in your repositories. Create and check
 in go.mod files. File issues at golang.org/issue, and please include “x/vgo:”
 at the start of the title. More posts tomorrow. Thanks, and have fun!
+
+### Version details
+
+```
+go version go1.10.2 linux/amd64 vgo:2018-02-20.1
+vgo commit: b39cea3cb5353f4fc7f08919d32a0006ea3ed62a
+```
 
 <!-- END -->

--- a/001_vgo_tour/script.sh
+++ b/001_vgo_tour/script.sh
@@ -199,7 +199,7 @@ vgo test all
 assert "$? -eq 0" $LINENO
 
 # block: prepare local quote
-git clone https://github.com/rsc/quote ../quote
+git clone -q https://github.com/rsc/quote ../quote
 
 # block: update quote.go
 cd ../quote
@@ -226,7 +226,7 @@ assert "$? -eq 0" $LINENO
 ensure_github_repo "vgo-by-example-quote-fork"
 assert "$? -eq 0" $LINENO
 pushd ../quote > /dev/null
-git push -f https://github.com/$GITHUB_USERNAME/vgo-by-example-quote-fork :v0.0.0-myfork
+git push -q -f https://github.com/$GITHUB_USERNAME/vgo-by-example-quote-fork :v0.0.0-myfork
 popd > /dev/null
 
 # block: setup our quote
@@ -235,7 +235,7 @@ git commit -a -m 'my fork'
 assert "$? -eq 0" $LINENO
 git tag v0.0.0-myfork
 assert "$? -eq 0" $LINENO
-git push https://github.com/$GITHUB_USERNAME/vgo-by-example-quote-fork v0.0.0-myfork
+git push -q https://github.com/$GITHUB_USERNAME/vgo-by-example-quote-fork v0.0.0-myfork
 assert "$? -eq 0" $LINENO
 
 # block: use our quote
@@ -263,3 +263,8 @@ go tool nm hello | grep sampler.hello
 assert "$? -eq 0" $LINENO
 go tool nm vhello | grep sampler.hello
 assert "$? -eq 0" $LINENO
+
+# block: version details
+vgo version
+echo "vgo commit: $(command cd $(go list -f "{{.Dir}}" golang.org/x/vgo); git rev-parse HEAD)"
+

--- a/002_using_gopkg_in/README.md
+++ b/002_using_gopkg_in/README.md
@@ -1,4 +1,4 @@
-<!-- __JSON: egrunner script.sh
+<!-- __JSON: egrunner script.sh # LONG ONLINE
 
 ### Intro
 
@@ -63,6 +63,12 @@ We can check go.mod for the exact version that was resolved:
 
 Notice that the previously resolved v1 of the yaml package remains in the go.mod file. Pruning or trimming of
 dependencies is being discussed in https://github.com/golang/go/issues/24101.
+
+### Version details
+
+```
+{{PrintBlockOut "version details" -}}
+```
 
 -->
 
@@ -196,5 +202,12 @@ require (
 
 Notice that the previously resolved v1 of the yaml package remains in the go.mod file. Pruning or trimming of
 dependencies is being discussed in https://github.com/golang/go/issues/24101.
+
+### Version details
+
+```
+go version go1.10.2 linux/amd64 vgo:2018-02-20.1
+vgo commit: b39cea3cb5353f4fc7f08919d32a0006ea3ed62a
+```
 
 <!-- END -->

--- a/002_using_gopkg_in/script.sh
+++ b/002_using_gopkg_in/script.sh
@@ -130,3 +130,7 @@ assert "$? -eq 0" $LINENO
 
 # block: cat go.mod v2
 cat go.mod
+
+# block: version details
+vgo version
+echo "vgo commit: $(command cd $(go list -f "{{.Dir}}" golang.org/x/vgo); git rev-parse HEAD)"

--- a/README.md
+++ b/README.md
@@ -14,11 +14,17 @@ A guide simply comprises a README.md and an accompanying bash script. The README
 script acts as a reproducible set of steps (that can be tested) for the guide. For example, the vgo tour has been
 rewritten as a vgo by example guide:
 
+<!-- __TEMPLATE: sh -c "cmd=\"ls 001_vgo_tour\"; echo \"${DOLLAR}cmd\"; ${DOLLAR}cmd"
 ```
-$ ls vgo_tour
+$ {{. -}}
+```
+-->
+```
+$ ls 001_vgo_tour
 README.md
 script.sh
 ```
+<!-- END -->
 
 script.sh contains, as its name suggests, the overall script for the guide. It includes a pre-amble that defines a
 number of helper functions for testing the script, followed by the header:
@@ -55,9 +61,15 @@ and [corresponding script](https://github.com/myitcv/vgo-by-example/blob/master/
 To ensure reproducibility and isolation, scripts are run in a Docker container; the
 [`golang`](https://hub.docker.com/_/golang/) container is used:
 
+<!-- __TEMPLATE: sh -c "cmd=\"docker pull golang\"; echo \"${DOLLAR}cmd\"; ${DOLLAR}cmd > /dev/null" # LONG ONLINE
+```
+{{. -}}
+```
+-->
 ```
 docker pull golang
 ```
+<!-- END -->
 
 The following two environment variables must be set:
 
@@ -70,29 +82,53 @@ _[Create a new personal access token](https://github.com/settings/tokens/new)._
 
 Ensure `egrunner` is installed (and on your PATH):
 
+<!-- __TEMPLATE: sh -c "cmd=\"go install myitcv.io/vgo-by-example/cmd/egrunner\"; echo \"${DOLLAR}cmd\"; ${DOLLAR}cmd > /dev/null"
+```
+{{. -}}
+```
+-->
 ```
 go install myitcv.io/vgo-by-example/cmd/egrunner
 ```
+<!-- END -->
 
 Now run in debug mode to see real-time output:
 
+<!-- __TEMPLATE: sh -c "cmd=\"egrunner -debug ./001_vgo_tour/script.sh\"; echo \"${DOLLAR}cmd\"; ${DOLLAR}cmd > /dev/null 2>&1" # LONG ONLINE
+```
+{{. -}}
+```
+-->
 ```
 egrunner -debug ./001_vgo_tour/script.sh
 ```
+<!-- END -->
 
 ### Regenerating a guide
 
 First ensure `mdreplace` and `egrunner` are installed (and on your PATH):
 
+<!-- __TEMPLATE: sh -c "cmd=\"go install myitcv.io/vgo-by-example/cmd/egrunner myitcv.io/vgo-by-example/cmd/mdreplace\"; echo \"${DOLLAR}cmd\"; ${DOLLAR}cmd > /dev/null"
 ```
-go install myitcv.io/vgo-by-example/cmd/mdreplace myitcv.io/vgo-by-example/cmd/egrunner
+{{. -}}
 ```
+-->
+```
+go install myitcv.io/vgo-by-example/cmd/egrunner myitcv.io/vgo-by-example/cmd/mdreplace
+```
+<!-- END -->
 
 Then re-run `mdreplace` on a guide template, e.g. for the vgo tour:
 
+<!-- __TEMPLATE: sh -c "cmd=\"mdreplace -w ./001_vgo_tour/README.md\"; echo \"${DOLLAR}cmd\"; ${DOLLAR}cmd > /dev/null 2>&1" # LONG ONLINE
+```
+{{. -}}
+```
+-->
 ```
 mdreplace -w ./001_vgo_tour/README.md
 ```
+<!-- END -->
 
 ### Caveats and TODO
 
@@ -105,5 +141,5 @@ This project is:
 TODO:
 
 * Automate the building of a table of contents in this README
-* Make this a `vgo` project
-* Move away from vendor of `mvdan.cc/sh` - currently vendoring to work around an issue with single statement printing.
+* Make this a vgo project
+* Move away from vendor of mvdan.cc/sh - currently vendoring to work around an issue with single statement printing.

--- a/cmd/egrunner/main.go
+++ b/cmd/egrunner/main.go
@@ -231,7 +231,7 @@ EOD
 	user := os.Getenv("GITHUB_USERNAME")
 	pat := os.Getenv("GITHUB_PAT")
 
-	cmd := exec.Command("docker", "run", "--rm", "-v", fmt.Sprintf("%v:/%v", tfn, scriptName), "-e", "GITHUB_PAT="+pat, "-e", "GITHUB_USERNAME="+user, "--entrypoint", "bash", "golang", fmt.Sprintf("/%v", scriptName))
+	cmd := exec.Command("docker", "run", "--rm", "-t", "-v", fmt.Sprintf("%v:/%v", tfn, scriptName), "-e", "GITHUB_PAT="+pat, "-e", "GITHUB_USERNAME="+user, "--entrypoint", "bash", "golang", fmt.Sprintf("/%v", scriptName))
 	debugf("now running %v via %v\n", tfn, strings.Join(cmd.Args, " "))
 
 	if debug || *fDebug {

--- a/cmd/mdreplace/common_block.go
+++ b/cmd/mdreplace/common_block.go
@@ -205,6 +205,24 @@ Args:
 			return ""
 		}
 
+		tmplFuncMap["PrintBlockOut"] = func(k string) string {
+			m := i.(map[string]interface{})
+			if bs, ok := m["Blocks"]; ok {
+				bsm := bs.(map[string]interface{})
+				if v, ok := bsm[k]; ok {
+					vs := v.([]interface{})
+					res := new(strings.Builder)
+					for _, j := range vs {
+						jj := j.(map[string]interface{})
+						fmt.Fprintf(res, "%v", jj["Out"])
+					}
+					return res.String()
+				}
+			}
+
+			return ""
+		}
+
 		t, err := template.New("").Funcs(tmplFuncMap).Parse(tmpl.String())
 		if err != nil {
 			p.errorf("failed to parse template %q: %e", tmpl, err)


### PR DESCRIPTION
* Add vgo version details to each guide
* Annotate mdreplace commands with `LONG` and `ONLINE` flags as appropriate
* Use mdreplace in core README.md